### PR TITLE
the stack

### DIFF
--- a/content/posts/2026-05-24-the-stack.md
+++ b/content/posts/2026-05-24-the-stack.md
@@ -1,0 +1,29 @@
+---
+title: "the stack"
+date: 2026-05-24
+draft: false
+categories: ["infra"]
+tags: ["mcp", "homelab", "cloudflare", "truenas", "bazzite"]
+summary: "Two machines, six MCP servers, a handful of Cloudflare tunnels, and one agent that writes these posts. What's actually running behind superterran.net."
+---
+
+Two machines carry the weight.
+
+The gaming/dev workstation is a Bazzite box running an AMD Ryzen 9 9950X and an RTX 4070 with 64GB RAM. Bazzite is Fedora Silverblue with Gamescope layered on — immutable OS, rpm-ostree for anything that needs to touch the system layer. The machine handles anything that requires GPU or local filesystem access: Ollama for local LLMs, Kokoro for TTS, Speaches for STT.
+
+The other machine is a 4-core Celeron NAS in the closet running TrueNAS SCALE, 32GB ECC. No discrete GPU. Doesn't need one. It runs the always-on services: the MCP servers, the OpenClaw gateway, Open WebUI, the Cloudflare tunnel to the outside world.
+
+Six MCP servers total:
+
+- `mcpvault` — reads my Obsidian vault over SSE. Session logs, machine profiles, agent context, skills.
+- `basic-memory` — knowledge graph, HTTP transport. Distilled decisions and facts that outlast individual sessions.
+- `wellbeing` — personal health data surface. It exists; its contents stay private.
+- `dndbeyond` — D&D character and campaign data scraped via CobaltSession cookie. One of the agents is a D&D companion; he needs this one.
+- `task-dispatch` — dispatches Claude Code as subprocesses. Can't move this one to the NAS because it forks the Claude CLI, which lives on the workstation.
+- `context7` — library docs, runs as a local stdio process.
+
+Auth pattern for anything network-accessible: Cloudflare tunnel to the NAS, Caddy in front of each server as a bearer-token proxy. Cloudflare Access doesn't work for direct API clients — it intercepts tunnel traffic and expects a browser with cookie support. Bearer via Caddy is the workaround that actually functions.
+
+On top of this: five OpenClaw agents running on the NAS gateway. Each gets its own Slack persona, its own lane definition, its own slice of the MCP surface. Hobbs is the personal ops one. He's the one that runs the cron that reads session logs and opens PRs against this repo.
+
+The editorial pass is the only thing in this pipeline that's manual. The rest is automated.

--- a/content/posts/2026-05-24-the-stack.md
+++ b/content/posts/2026-05-24-the-stack.md
@@ -4,26 +4,26 @@ date: 2026-05-24
 draft: false
 categories: ["infra"]
 tags: ["mcp", "homelab", "cloudflare", "truenas", "bazzite"]
-summary: "Two machines, six MCP servers, a handful of Cloudflare tunnels, and one agent that writes these posts. What's actually running behind superterran.net."
+summary: "Two machines, six MCP servers, Cloudflare tunnels, and one agent that writes these posts. What's running behind superterran.net."
 ---
 
 Two machines carry the weight.
 
-The gaming/dev workstation is a Bazzite box running an AMD Ryzen 9 9950X and an RTX 4070 with 64GB RAM. Bazzite is Fedora Silverblue with Gamescope layered on — immutable OS, rpm-ostree for anything that needs to touch the system layer. The machine handles anything that requires GPU or local filesystem access: Ollama for local LLMs, Kokoro for TTS, Speaches for STT.
+The gaming/dev workstation is a Bazzite box running an AMD Ryzen 9 9950X and an RTX 4070 with 64GB RAM. Bazzite is Fedora Silverblue with Gamescope layered on — immutable OS. The machine handles anything that requires GPU or local filesystem access: Ollama for local LLMs, Kokoro for TTS, Speaches for STT.
 
-The other machine is a 4-core Celeron NAS in the closet running TrueNAS SCALE, 32GB ECC. No discrete GPU. Doesn't need one. It runs the always-on services: the MCP servers, the OpenClaw gateway, Open WebUI, the Cloudflare tunnel to the outside world.
+The other machine is a 4-core Celeron NAS in the closet running TrueNAS SCALE with 32GB ECC. No discrete GPU, doesn't need one. It runs the always-on services: MCP servers, the OpenClaw gateway, Open WebUI, and the Cloudflare tunnel outward.
 
 Six MCP servers total:
 
 - `mcpvault` — reads my Obsidian vault over SSE. Session logs, machine profiles, agent context, skills.
 - `basic-memory` — knowledge graph, HTTP transport. Distilled decisions and facts that outlast individual sessions.
 - `wellbeing` — personal health data surface. It exists; its contents stay private.
-- `dndbeyond` — D&D character and campaign data scraped via CobaltSession cookie. One of the agents is a D&D companion; he needs this one.
-- `task-dispatch` — dispatches Claude Code as subprocesses. Can't move this one to the NAS because it forks the Claude CLI, which lives on the workstation.
+- `dndbeyond` — D&D character and campaign data. One of the agents is a campaign companion; he needs this one.
+- `task-dispatch` — dispatches Claude Code as subprocesses. Stays on the workstation.
 - `context7` — library docs, runs as a local stdio process.
 
-Auth pattern for anything network-accessible: Cloudflare tunnel to the NAS, Caddy in front of each server as a bearer-token proxy. Cloudflare Access doesn't work for direct API clients — it intercepts tunnel traffic and expects a browser with cookie support. Bearer via Caddy is the workaround that actually functions.
+Network-accessible servers sit behind Cloudflare tunnels with bearer-token auth proxied by Caddy. LAN clients skip the proxy and hit services directly. The published `*.superterran.net` hostnames are the only externally-reachable surface.
 
-On top of this: five OpenClaw agents running on the NAS gateway. Each gets its own Slack persona, its own lane definition, its own slice of the MCP surface. Hobbs is the personal ops one. He's the one that runs the cron that reads session logs and opens PRs against this repo.
+On top of this: five OpenClaw agents running on the NAS gateway. Each gets its own Slack persona, its own lane definition, its own slice of the MCP surface. Hobbs is the personal ops one — the agent that reads session logs and opens PRs against this repo.
 
-The editorial pass is the only thing in this pipeline that's manual. The rest is automated.
+The editorial pass is the only thing in this pipeline that's manual.


### PR DESCRIPTION
Source: bazzite-desktop machine profile + session history (2026-05-16 closet migration, 2026-05-17 OpenClaw agents, 2026-05-23 SSH wiring). Post-worthy because it's the reference piece Doug asked for — maps the full MCP/infra surface as the "about the stack" doc for the site.

**Guardrail self-check:**
- Hard-banned topics avoided? Yes — no client names, no household content, no wellbeing data, no confidential channels.
- All proper nouns public infra/tools/first name? Yes — bazzite, TrueNAS SCALE, Ollama, Kokoro, Speaches, OpenClaw, Cloudflare, Caddy are all public tools/products. No LAN IPs included.
- Title passes voice ban list? Yes — lowercase, fragmentary, no "How I", no alliteration.
- Under 1000 words? Yes (~280 words).
- No CTA or wrap-up paragraph? Yes — ends on "The editorial pass is the only thing in this pipeline that's manual."
- Content from confidential channel? No.