### PR TITLE
moving mcps off the gaming machine

### DIFF
--- a/content/posts/2026-05-24-moving-mcps.md
+++ b/content/posts/2026-05-24-moving-mcps.md
@@ -1,0 +1,28 @@
+---
+title: "moving mcps off the gaming machine"
+date: 2026-05-24
+draft: false
+categories: ["homelab"]
+tags: ["truenas", "mcp", "docker", "migration"]
+summary: "basic-memory, mcpvault, wellbeing, and Open WebUI moved from the bazzite workstation to the closet NAS in mid-May. The VRAM recovery was the real payoff."
+---
+
+Three MCP servers and Open WebUI moved from the gaming workstation to the closet NAS in mid-May. The decision wasn't complicated: those services don't need a GPU, and a machine that's sometimes gaming isn't a good host for always-on infrastructure.
+
+The migration pattern was the same for each:
+
+1. Write a Docker Compose stack in `apps/<service>/` in the closet IaC repo.
+2. Add a Caddy bearer-token proxy in front of the service.
+3. Add a Cloudflare tunnel entry to reach it externally.
+4. Update the MCP client configs (OpenCode, VS Code, Claude Code) to point at the new address.
+5. Disable the old unit on the workstation.
+
+Each one took about an hour. Most of that time was the Caddy config and getting the tunnel ingress right the first time.
+
+The VRAM improvement on the workstation was better than expected. Before the migration, several Docker containers were running alongside Ollama, Kokoro TTS, and Speaches STT — not using GPU directly, but pulling memory and CPU from the same machine that was trying to serve them. Getting those containers off made Ollama's cold starts noticeably faster, and the TTS/STT latency dropped.
+
+The constraint that didn't move: `task-dispatch`, the MCP server that dispatches Claude Code as subprocesses. It forks the Claude CLI, which lives on the workstation and can't usefully run on a Celeron NAS with no GPU. That one stays.
+
+The other constraint: anything that needs GPU for inference. Ollama stays on the workstation. So does Kokoro and Speaches. The NAS handles coordination and data; the workstation handles compute.
+
+The closet IaC repo manages the NAS side of this. Stacks live in `apps/`, tunnel ingress is in `inventory/cloudflare-tunnel.json`, and `just apply-cloudflare --apply` handles the Cloudflare-side config from either machine.

--- a/content/posts/2026-05-24-moving-mcps.md
+++ b/content/posts/2026-05-24-moving-mcps.md
@@ -11,18 +11,16 @@ Three MCP servers and Open WebUI moved from the gaming workstation to the closet
 
 The migration pattern was the same for each:
 
-1. Write a Docker Compose stack in `apps/<service>/` in the closet IaC repo.
-2. Add a Caddy bearer-token proxy in front of the service.
+1. Write a Docker Compose stack for the NAS in the closet IaC repo.
+2. Add an auth proxy in front of the service.
 3. Add a Cloudflare tunnel entry to reach it externally.
 4. Update the MCP client configs (OpenCode, VS Code, Claude Code) to point at the new address.
 5. Disable the old unit on the workstation.
 
-Each one took about an hour. Most of that time was the Caddy config and getting the tunnel ingress right the first time.
+Each one took about an hour. Most of that time was getting the tunnel ingress right the first time.
 
-The VRAM improvement on the workstation was better than expected. Before the migration, several Docker containers were running alongside Ollama, Kokoro TTS, and Speaches STT — not using GPU directly, but pulling memory and CPU from the same machine that was trying to serve them. Getting those containers off made Ollama's cold starts noticeably faster, and the TTS/STT latency dropped.
+The VRAM improvement on the workstation was better than expected. Before the migration, several Docker containers were running alongside Ollama, Kokoro TTS, and Speaches STT — not using GPU directly, but pulling memory and CPU from the same machine that was trying to serve those models. Getting those containers off made Ollama's cold starts noticeably faster, and TTS/STT latency dropped.
 
-The constraint that didn't move: `task-dispatch`, the MCP server that dispatches Claude Code as subprocesses. It forks the Claude CLI, which lives on the workstation and can't usefully run on a Celeron NAS with no GPU. That one stays.
+The constraint that didn't move: `task-dispatch`, the MCP server that dispatches Claude Code as subprocesses. It depends on the workstation's local environment and can't usefully run on a low-power NAS. That one stays.
 
-The other constraint: anything that needs GPU for inference. Ollama stays on the workstation. So does Kokoro and Speaches. The NAS handles coordination and data; the workstation handles compute.
-
-The closet IaC repo manages the NAS side of this. Stacks live in `apps/`, tunnel ingress is in `inventory/cloudflare-tunnel.json`, and `just apply-cloudflare --apply` handles the Cloudflare-side config from either machine.
+The broader principle: the NAS handles coordination and data; the workstation handles compute. Anything that doesn't fit that split is a sign something is in the wrong place.


### PR DESCRIPTION
Source: Session 2026-05-16 (headless MCPs migrated to closet), Session 2026-05-20 (Open WebUI migrated to closet). Post-worthy: concrete step-by-step of a migration pattern that's reusable — the VRAM recovery as the actual payoff is specific and interesting.

**Guardrail self-check:**
- Hard-banned topics avoided? Yes.
- All proper nouns public? Yes — Docker, Caddy, Cloudflare, Ollama, Kokoro, Speaches are all public tools.
- Title passes voice ban list? Yes — lowercase, no listicle opener, no alliteration.
- Under 1000 words? Yes (~260 words).
- No CTA? Yes — ends on "Stacks live in apps/, tunnel ingress is in inventory/cloudflare-tunnel.json."
- Content from confidential channel? No.