### PR TITLE
site: terminal theme + profile homepage

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1,0 +1,16 @@
+/* tighten the profile card spacing */
+article header h1 {
+  letter-spacing: -0.02em;
+}
+
+/* make inline code pop a bit more on the terminal scheme */
+code:not(pre code) {
+  font-size: 0.88em;
+}
+
+/* post cards: slightly warmer hover on the terminal green */
+.hover\:shadow-md:hover {
+  transition: box-shadow 0.15s ease;
+}
+
+/* footer: drop "Powered by Blowfish" — already disabled in params */

--- a/config/_default/languages.en.toml
+++ b/config/_default/languages.en.toml
@@ -13,9 +13,11 @@ title = "superterran.net"
 
 [params.author]
   name = "Doug Hatcher"
-  headline = "Enterprise Architect. Tinkerer. This is the workshop."
-  bio = "An auto-narrated feed of personal projects, homelab notes, and whatever I'm actually doing — operated by an agent under guardrails, merged by me."
+  image = "https://github.com/superterran.png"
+  headline = "Enterprise Architect. Homelab obsessive. The workshop floor."
+  bio = "Building things in public — homelab, MCP/agent infrastructure, Cloudflare tunnels, whatever I'm tinkering with. The blog is operated by an agent under editorial guardrails, merged by me."
   links = [
     { github = "https://github.com/superterran" },
     { link = "https://doughatcher.com" },
+    { rss = "/index.xml" },
   ]

--- a/config/_default/menus.en.toml
+++ b/config/_default/menus.en.toml
@@ -20,5 +20,10 @@
 
 [[footer]]
   name = "GitHub"
-  url = "https://github.com/superterran/superterran.github.io"
+  url = "https://github.com/superterran"
   weight = 20
+
+[[footer]]
+  name = "RSS"
+  url = "/index.xml"
+  weight = 30

--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -1,6 +1,6 @@
-colorScheme = "slate"
+colorScheme = "terminal"
 defaultAppearance = "dark"
-autoSwitchAppearance = true
+autoSwitchAppearance = false
 
 enableA11y = false
 enableSearch = true
@@ -22,14 +22,14 @@ fingerprintAlgorithm = "sha512"
 [footer]
   showMenu = true
   showCopyright = true
-  showThemeAttribution = true
-  showAppearanceSwitcher = true
+  showThemeAttribution = false
+  showAppearanceSwitcher = false
   showScrollToTop = true
 
 [homepage]
-  layout = "card"
+  layout = "profile"
   showRecent = true
-  showRecentItems = 12
+  showRecentItems = 8
   showMoreLink = true
   showMoreLinkDest = "/posts/"
   cardView = true
@@ -41,9 +41,10 @@ fingerprintAlgorithm = "sha512"
   showViews = false
   showLikes = false
   showDateOnlyInArticle = false
-  showDateUpdated = true
-  showAuthor = true
-  showHero = false
+  showDateUpdated = false
+  showAuthor = false
+  showHero = true
+  heroStyle = "basic"
   showBreadcrumbs = false
   showDraftLabel = true
   showEdit = true
@@ -54,7 +55,7 @@ fingerprintAlgorithm = "sha512"
   showPagination = true
   invertPagination = false
   showReadingTime = true
-  showTableOfContents = true
+  showTableOfContents = false
   showTaxonomies = true
   showCategories = true
   showTags = true


### PR DESCRIPTION
Switches from generic slate card layout to something more distinctive:

- **Color scheme**: slate → terminal (dark green on black, fits the homelab/workshop vibe)
- **Homepage layout**: card → profile (author card at top with avatar, bio, links; recent posts below)
- **Author image**: added GitHub avatar (https://github.com/superterran.png)
- **Author bio**: tightened wording, added RSS link
- **Theme attribution**: removed from footer (cleaner)
- **Appearance switcher**: removed (terminal scheme does not make sense in light mode)
- **Article hero**: enabled (heroStyle=basic; will use post images when we add them)
- **RSS**: added to nav footer
- **Custom CSS**: minimal tweaks to code readability and card hover

No hard editorial rules in scope for this PR — config/theme only.