### PR TITLE
wire in Google Analytics (G-SKSP40VDN9)

### DIFF
--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -8,6 +8,8 @@ buildDrafts = false
 buildFuture = false
 enableEmoji = true
 
+googleAnalytics = "G-SKSP40VDN9"
+
 [pagination]
   pagerSize = 20
 


### PR DESCRIPTION
Adds GA4 tag via Blowfish's built-in `googleAnalytics` config key — the theme injects gtag.js automatically when set. No partial overrides.

Verified locally:
```
$ grep -o 'G-SKSP40VDN9' public/index.html
G-SKSP40VDN9
```

In flight: syndication ladder (Echofeed vs micro.blog feed-only, rel='me' verification, sitemap → Search Console) still to wire.