### PR TITLE
uv on zfs wanted copy mode

### DIFF
--- a/content/posts/2026-05-25-uv-on-zfs.md
+++ b/content/posts/2026-05-25-uv-on-zfs.md
@@ -1,0 +1,32 @@
+---
+title: "uv on zfs wanted copy mode"
+date: 2026-05-25
+draft: false
+categories: ["mcp"]
+tags: ["uv", "zfs", "mcp", "truenas"]
+summary: "The first MCP migration to the closet NAS hit a small uv-on-ZFS failure that was easier to fix than to diagnose."
+---
+
+The first MCP I moved to the closet NAS failed in the least glamorous place: dependency setup.
+
+The service itself was boring. Docker Compose stack, persistent app data, auth proxy, tunnel, client configs. The kind of migration that feels like it should be mechanical after the second one.
+
+Then `uv` hit ZFS and threw:
+
+```text
+Resource temporarily unavailable (os error 11)
+```
+
+That was the real post. Not the service. Not the tunnel. The tiny filesystem mismatch hiding under a migration that otherwise looked routine.
+
+`uv` likes to link package files when it can. On this dataset, in this container shape, that was not the happy path. The fix was:
+
+```text
+UV_LINK_MODE=copy
+```
+
+After that, the service came up cleanly.
+
+I also had to correct a wrong mental model while I was in there. I had been treating basic-memory as if it depended on the Obsidian vault replica. It does not. The projects and database are its own thing. That mattered because it meant basic-memory could be the first service moved instead of waiting for the whole vault-sync chain to be ready.
+
+That is the useful migration order: move the thing with the fewest hidden dependencies first. Let it establish the stack pattern. Then move the messier services after the boring path has already been proven.


### PR DESCRIPTION
Source: main/sessions/session-2026-05-16-basic-memory-mcp-migrated-to-closet

This is post-worthy because it extracts the concrete gotcha from the first closet MCP migration: uv link mode failed on the NAS dataset, and copy mode made the migration boring again.

## Guardrail self-check

- Avoids all hard-banned topics: YES
- No real names from work / household / agents: YES
- Title passes voice ban list: YES
- Under 1000 words, or justified: YES
- No CTA / wrap-up paragraph: YES
- No content from confidential channels: YES

## OpSec/redaction pass

- Omitted internal paths, LAN ports, token/auth mechanics, Cloudflare ingress details, and repo management commands.
- Kept only the non-sensitive failure message and environment setting.