### PR TITLE
cloudflared quick tunnel, wrong config

### DIFF
--- a/content/posts/2026-05-31-cloudflared-quick-tunnel-wrong-config.md
+++ b/content/posts/2026-05-31-cloudflared-quick-tunnel-wrong-config.md
@@ -1,0 +1,20 @@
+---
+title: "cloudflared quick tunnel, wrong config"
+date: 2026-05-31
+draft: false
+categories: ["infra"]
+tags: ["cloudflare", "tunnel", "networking", "gotcha"]
+summary: "Quick tunnels pick up ~/.cloudflared/config.yml if it exists, and route through your named tunnel\'s ingress instead of the trycloudflare URL."
+---
+
+Ran `cloudflared tunnel --url localhost:1313` on a machine that also has a named Cloudflare tunnel configured at `~/.cloudflared/config.yml`. Got a `trycloudflare.com` URL back. Opened it. `404 Not Found`.
+
+What\'s happening: cloudflared finds the config file and treats the process as a named tunnel invocation. The `trycloudflare.com` URL gets minted fine, but traffic routes through the named tunnel\'s ingress rules — which have no entry for `localhost:1313`. The URL is real, the routing is wrong.
+
+Fix:
+
+```
+cloudflared --config /dev/null tunnel --url localhost:1313
+```
+
+No config file, no named tunnel context. The quick tunnel runs clean.


### PR DESCRIPTION
## Source

Session: 2026-05-30 — Dougie theme v2.5 refactor

Hit this while setting up a Cloudflare quick tunnel to preview a Hugo build. Machine already had `~/.cloudflared/config.yml` with a named tunnel configured. The quick tunnel URL was real but 404'd — traffic was routing through the named tunnel's ingress. `--config /dev/null` fixes it. One of those things that took a while to see.

## Guardrail self-check

- **No hard-banned topics?** YES — pure Cloudflare networking, no work names, no household, no confidential channels, no wellbeing, no BA work.
- **All proper nouns public?** YES — Cloudflare and trycloudflare.com are widely-known public services.
- **Title passes voice ban list?** YES — lowercase, fragmentary, no alliteration, no "How I", no listicle.
- **Under 1000 words?** YES — ~120 words.
- **No CTA or wrap-up paragraph?** YES — ends at the fix.
- **Content from confidential channel?** NO.