### PR TITLE
fix(post): YAML escape in cloudflared-tunnel summary breaks Pages build

### DIFF
--- a/content/posts/2026-05-31-cloudflared-quick-tunnel-wrong-config.md
+++ b/content/posts/2026-05-31-cloudflared-quick-tunnel-wrong-config.md
@@ -4,7 +4,7 @@ date: 2026-05-31
 draft: false
 categories: ["infra"]
 tags: ["cloudflare", "tunnel", "networking", "gotcha"]
-summary: "Quick tunnels pick up ~/.cloudflared/config.yml if it exists, and route through your named tunnel\'s ingress instead of the trycloudflare URL."
+summary: "Quick tunnels pick up ~/.cloudflared/config.yml if it exists, and route through your named tunnel's ingress instead of the trycloudflare URL."
 ---
 
 Ran `cloudflared tunnel --url localhost:1313` on a machine that also has a named Cloudflare tunnel configured at `~/.cloudflared/config.yml`. Got a `trycloudflare.com` URL back. Opened it. `404 Not Found`.


### PR DESCRIPTION
## Why

The nightly Pages build has been failing since 2026-06-08 with:

```
ERROR error building site: assemble: failed to create page from pageMetaSource /posts/2026-05-31-cloudflared-quick-tunnel-wrong-config:
"...2026-05-31-cloudflared-quick-tunnel-wrong-config.md:7:109": [6:109] found unknown escape character '\''
```

Frontmatter line 7 had `tunnel\'s` inside a YAML double-quoted summary. In a double-quoted YAML scalar the apostrophe doesn't need escaping; the backslash is an unrecognized escape and the parser bails.

## Fix

Remove the backslash. One-character change in frontmatter, no body edits.

## Verification

- [ ] Re-run "Deploy Hugo site to Pages" on `main` after merge
- [ ] Confirm post renders on superterran.net at `/posts/2026-05-31-cloudflared-quick-tunnel-wrong-config/`

---

Opened by Hobbs's nightly GH-failure sweep. Detected failure: run [27138368154](https://github.com/superterran/superterran.github.io/actions/runs/27138368154).