### PR TITLE
sunshine flatpak won't do kms capture

### DIFF
--- a/content/posts/2026-06-10-sunshine-flatpak-kms.md
+++ b/content/posts/2026-06-10-sunshine-flatpak-kms.md
@@ -1,0 +1,33 @@
+---
+title: "sunshine flatpak won't do kms capture"
+date: 2026-06-10
+draft: false
+categories: ["homelab"]
+tags: ["sunshine", "moonlight", "bazzite", "kms", "flatpak"]
+summary: "Moonlight showed the app list but every stream failed. The flatpak build can't hold CAP_SYS_ADMIN, so KMS capture is structurally off the table."
+---
+
+Moonlight showed the app list. Every stream attempt died immediately with "failed to initialize display." Sunshine was running — `systemctl --user status` showed active, no crash. Logs said nothing obvious at first glance.
+
+The day before, as part of a headless streaming experiment, the brew-native Sunshine had been uninstalled and replaced with the Flatpak. That was the problem.
+
+The log, once I looked in the right place (`~/.var/app/dev.lizardbyte.app.Sunshine/.../sunshine.log`):
+
+```
+Fatal: AppImage and Flatpak do not support KMS capture
+WAYLAND_DISPLAY has not been defined
+```
+
+The Flatpak runs inside a `bwrap` sandbox. KMS capture requires `CAP_SYS_ADMIN` — you need direct access to the DRI device. The bwrap sandbox structurally can't hold that capability. So the Flatpak build will start, list apps, accept connections, and then fail silently on capture every time. No stream, no error surfaced to the client.
+
+`ujust setup-sunshine` on Bazzite shows the supported path: the brew package via `LizardByte/homebrew`, not the Flatpak. The postinst script sets the caps on the binary directly:
+
+```
+cap_sys_admin,cap_sys_nice=p
+```
+
+No sandbox. Direct device access. That's the only path that works for KMS mirroring on a bare-metal Bazzite box.
+
+Uninstalled the Flatpak, pulled the brew package, ran the postinst, wrote a clean config with `capture = kms` and `encoder = nvenc`. First start showed "Screencasting with KMS" in the log. Streams worked.
+
+Worth noting: a fresh install drops the previous client certs. The web UI needs a new admin credential set before Moonlight will pair.


### PR DESCRIPTION
Source: [2026-06-06-sunshine-restore-and-ram-stress-test](vault/context/sessions/2026-06-06-sunshine-restore-and-ram-stress-test) session log.

Post-worthy because: the flatpak build silently fails at KMS capture (can't hold CAP_SYS_ADMIN in the bwrap sandbox), which is non-obvious when Sunshine shows as active and Moonlight shows the app list. The supported path on Bazzite is the brew package — documented by ujust but easy to miss if you go to Discover first.

## Guardrail self-check

- Does the post avoid all hard-banned topics? **YES** — no work names, no household, no BA clients, no wellbeing data, no secrets/tokens/IPs.
- Are all proper nouns public tools or Doug's own? **YES** — Sunshine, Moonlight, Bazzite, LizardByte/homebrew, bwrap are all widely known.
- Does the title pass the voice ban list? **YES** — no alliteration, no "How I", no listicle opener.
- Is the post under 1000 words? **YES** — ~280 words.
- Does the post end without a CTA or wrap-up? **YES** — ends on the pairing note.
- Any content from confidential channels? **NO.**