### PR TITLE
"thinkingDefault: medium" silently means off

### DIFF
--- a/content/posts/2026-06-12-thinking-medium-is-off.md
+++ b/content/posts/2026-06-12-thinking-medium-is-off.md
@@ -1,0 +1,28 @@
+---
+title: '"thinkingDefault: medium" silently means off'
+date: 2026-06-12
+draft: false
+categories: ["ai"]
+tags: ["openclaw", "claude", "agents", "gotcha"]
+summary: "Setting thinkingDefault to medium in an OpenClaw agent config does nothing. The valid values are low and high; medium gets silently dropped to off."
+---
+
+The config key in question:
+
+```json
+"thinkingDefault": "medium"
+```
+
+This looked reasonable. More reasoning than `low`, less than `high`. Moderate. The sane default.
+
+Except "medium" is not a valid value on Claude 4.6/4.7. The actual enum is `[low, high]` — there is no middle. OpenClaw accepts the config without complaint, silently downgrades to `off`, and your agents proceed with no extended reasoning at all.
+
+I had this set across four agents for at least a few weeks. The agents were running fine — tool calls, normal responses — but none of the reasoning that `thinkingDefault` is supposed to enable was happening. 15+ turns per day per agent, all quietly in `off` mode.
+
+Caught it during a fleet audit. The fix was one line in each agent config:
+
+```json
+"thinkingDefault": "low"
+```
+
+No error, no warning, no log line when the invalid value got swallowed. If you're running OpenClaw agents and have `thinkingDefault` set to anything besides `off`, `low`, or `high`, verify the actual model config it sends to the provider. Don't assume the gateway validated your input.


### PR DESCRIPTION
Source: Context/sessions/2026-06-11-fleet-review-tune.md

During a fleet audit I found that four agents had `thinkingDefault: "medium"` set in their OpenClaw configs. Claude 4.6/4.7 only accepts `low` or `high` — "medium" is silently dropped to `off`. The agents were running normally but with extended reasoning completely disabled for weeks without any log warning.

**Guardrail check (all YES required):**
- Avoids hard-banned topics (work clients, household, BA, wellbeing, secrets)? YES
- All proper nouns are public infra I own, widely-known tools, or my first name? YES
- Title passes voice ban list (no alliteration, no "How I", no listicle)? YES
- Under 1000 words (or specific reason if longer)? YES (~190 words)
- Ends without CTA or wrap-up paragraph? YES
- Content from a confidential channel? NO