### PR TITLE
the reasoning wasn't running

### DIFF
--- a/content/posts/2026-06-12-reasoning-wasnt-running.md
+++ b/content/posts/2026-06-12-reasoning-wasnt-running.md
@@ -1,0 +1,26 @@
+---
+title: "the reasoning wasn't running"
+date: 2026-06-12
+draft: false
+categories: ["ai"]
+tags: ["openclaw", "claude", "agents", "gotcha"]
+summary: "A fleet audit found four agents had been running without extended reasoning for weeks. The config looked fine. Behavior looked normal. Nothing paged."
+---
+
+The config key that started it:
+
+```json
+"thinkingDefault": "medium"
+```
+
+I did an end-to-end audit of my agent stack after a model upgrade. Found this across four agents. "medium" reads as the sensible middle ground. Not max reasoning, not off.
+
+Claude 4.6/4.7 doesn't have a medium. The valid values are `off`, `low`, `high`. OpenClaw accepted the config, dropped it to `off`, and didn't log anything.
+
+Four agents. Weeks. Fifteen or more turns a day. No extended reasoning during any of it. The responses looked normal. There was no way to notice from behavior alone — the model is still competent at `off`, it's just not running the way you configured it.
+
+Found a second version of the same failure while I was in there: the deploy script was defaulting to a model alias that had gotten misconfigured during a prior upgrade. Agents coherently running on a different model than the one I thought I'd pinned.
+
+Both caught by reading what the gateway was actually sending, not by noticing degraded output. Not by an alert.
+
+AI config rot doesn't fail loudly. It just runs at a different capability level than the one you set, and says nothing about it.


### PR DESCRIPTION
Source: Context/sessions/2026-06-11-fleet-review-tune.md

End-to-end fleet audit after a model upgrade found two silent config failures: `thinkingDefault: "medium"` accepted but dropped to `off` by the gateway, and a deploy script defaulting to a misconfigured model alias. Both ran for weeks with no alarms and normal-looking behavior. The broader observation: AI config rot doesn't fail loudly.

**Guardrail check (all YES required):**
- Avoids hard-banned topics (work clients, household, BA, wellbeing, secrets)? YES
- All proper nouns are public infra I own, widely-known tools, or my first name? YES
- Title passes voice ban list (no alliteration, no "How I", no listicle)? YES
- Under 1000 words (or specific reason if longer)? YES (~220 words)
- Ends without CTA or wrap-up paragraph? YES
- Content from a confidential channel? NO