### PR TITLE
post: final backlog batch — shared games arc + openclaw multi-agent coordination

### DIFF
--- a/content/posts/2026-03-28-shared-games-setup.md
+++ b/content/posts/2026-03-28-shared-games-setup.md
@@ -1,0 +1,49 @@
+---
+title: "shared game library with syncthing and steam shortcuts"
+date: 2026-03-28
+draft: false
+categories: ["homelab"]
+tags: ["gaming", "syncthing", "steam", "bazzite", "python"]
+summary: "A Syncthing folder for games shared between the desktop and the ROG Ally. Non-Steam shortcuts via the VDF library. One tricky int32 sign issue."
+---
+
+The goal: a game library that lives on a fast NVMe drive, syncs between bazzite-desktop and the ROG Ally, and shows up in Steam with proper artwork. Both machines can access the same saves. A setup script handles adding shortcuts so the process is repeatable when a new game gets added.
+
+## Structure
+
+```
+/var/mnt/fast/shared-games/
+  ghostship/         # SM64 GhostShip PC port
+    ghostship.AppImage
+    saves/
+    rom/             # stignored — ROMs don't sync
+  _setup/
+    setup-steam.sh   # adds shortcuts + downloads artwork
+    update-games.sh  # checks for new releases
+  .stignore          # ROM dirs excluded
+```
+
+ROMs are copyright-held and don't sync. Games that need them generate processed asset files on first launch (`.o2r`, `.otr`); those files do sync, so only one machine needs to do the generation step.
+
+## Adding non-Steam shortcuts via VDF
+
+Steam stores non-Steam shortcuts in a binary VDF file (`~/.local/share/Steam/userdata/<uid>/config/shortcuts.vdf`). The `vdf` Python library reads and writes this format. Running it via `uv run --with vdf` means no pip install required on any machine — uv handles the temporary environment.
+
+One gotcha: the VDF binary format stores the shortcut `appid` as a signed int32. Steam generates these by CRC32-hashing the exe path + app name. CRC32 values with the high bit set are negative when interpreted as signed int32 — passing them as Python's unsigned int raises a `struct.error`. Fix:
+
+```python
+import ctypes
+appid = ctypes.c_int32(unsigned_crc32_value).value
+```
+
+## Syncthing setup
+
+Syncthing 2.x stores config at `~/.local/state/syncthing/config.xml` — not `~/.config/syncthing/` as older docs suggest. The service can be added via REST API after install, which is what the setup script does rather than manually editing XML.
+
+## SteamGridDB artwork
+
+The setup script downloads capsule, wide, hero, and logo art from SteamGridDB when an API key is present in `~/.env`. Without the key it skips artwork gracefully. Artwork handling became more interesting once the Ally was added — see the fleet setup post.
+
+## Next steps captured
+
+At this point: Syncthing running on the desktop, `shared-games` folder created, GhostShip added. The Ally was next — a separate session to pair the devices and provision the other end.

--- a/content/posts/2026-03-29-ally-syncthing-games.md
+++ b/content/posts/2026-03-29-ally-syncthing-games.md
@@ -1,0 +1,54 @@
+---
+title: "provisioning the rog ally into the shared game library"
+date: 2026-03-29
+draft: false
+categories: ["homelab"]
+tags: ["gaming", "syncthing", "rog-ally", "steam", "bazzite", "ssh"]
+summary: "Adding the ROG Ally as a Syncthing peer. Battery-friendly settings, SSH remote provisioning, five games migrated from SD card to internal NVMe."
+---
+
+With the shared-games Syncthing folder running on bazzite-desktop, the next step was adding the ROG Ally. The Ally runs Bazzite — same OS family, same tooling — so provisioning it remotely via SSH is straightforward.
+
+## Battery-friendly Syncthing config
+
+The Ally is battery-powered. Default Syncthing settings assume a plugged-in machine: global relay servers, wide discovery scope, frequent rescans. On the Ally:
+
+- Global relays disabled (LAN-only sync)
+- Only local discovery enabled
+- Rescan interval: 10 minutes (vs. default 60 seconds)
+- Filesystem watcher: enabled (so changes trigger sync even with the long rescan interval)
+- Reconnect interval: 120 seconds
+
+The Ally and desktop only need to sync when on the same LAN, so there's no reason to route through relay servers.
+
+## SSH and mDNS
+
+Added the Ally to `~/.ssh/config` using its LAN IP directly. `ally.local` resolves fine via `avahi-resolve` in a terminal but doesn't reliably work as the `HostName` in `~/.ssh/config` from a bash script context. IP is stable enough for home LAN.
+
+## Games migrated
+
+Five games moved from the Ally's SD card to `shared-games` on the internal NVMe:
+
+| Game | Type | Save sync |
+|------|------|-----------|
+| GhostShip (SM64 PC port) | AppImage | In game dir |
+| Ship of Harkinian (OoT PC port) | AppImage | In game dir |
+| AM2R | Windows exe via Proton | Symlink from Proton prefix |
+| Link's Awakening DX HD | Windows exe via Proton | SaveFiles/ in game dir |
+| Super Mario Bros. Remastered | Native Linux (Godot) | Symlink to `~/.local/share/SMB1R/saves/` |
+
+The Proton-prefix games need a symlink so the Proton prefix points into the shared-games saves directory rather than keeping saves inside the prefix where they'd stay machine-local.
+
+## SM64 Remastered save symlink pattern
+
+SMB1R is a Godot game that writes saves to `~/.local/share/SMB1R/saves/`. The game doesn't have a config option to change this path. The workaround: put the actual saves directory inside `shared-games/smb1r/saves/`, then symlink `~/.local/share/SMB1R/saves/` to point there. Syncthing syncs the shared-games folder; the game sees the path it expects.
+
+The same pattern works for any game with a hardcoded save path.
+
+## Ally Syncthing device path
+
+The Ally's shared-games folder lives at `/home/bazzite/shared-games` — not `/var/mnt/fast/shared-games` like the desktop. Different paths, same Syncthing folder. This matters for Steam: shortcut `appid` is a CRC32 of the exe path plus the game name. Different paths mean different appids on each machine. Artwork lookup by appid breaks cross-device. The fleet setup session addressed this by switching to slug-keyed artwork caching.
+
+## Provisioning script
+
+`ally-setup.sh` automates the full remote setup: SSH key copy, Syncthing install, service enable, folder config via REST API, game setup script run. One script, one command from the desktop, Ally fully provisioned.

--- a/content/posts/2026-04-04-shared-games-fleet.md
+++ b/content/posts/2026-04-04-shared-games-fleet.md
@@ -1,0 +1,47 @@
+---
+title: "slug-keyed artwork cache and fleet provisioning for shared games"
+date: 2026-04-04
+draft: false
+categories: ["homelab"]
+tags: ["gaming", "syncthing", "steam", "rog-ally", "bazzite", "steamgriddb"]
+summary: "Artwork keyed by slug (not appid) so it syncs across machines. sync-peers.sh provisions the whole fleet from one command. Scripts pushed to GitHub."
+---
+
+Two things were missing after adding the Ally to the shared game library: artwork was being downloaded per-machine because it was keyed by Steam appid (which differs between devices when exe paths differ), and provisioning a new device still required running setup separately on each machine. Both got fixed.
+
+## Why appid-keyed artwork breaks across machines
+
+Steam generates the appid for non-Steam shortcuts by CRC32-hashing the exe path and app name. Since the desktop mounts shared-games at `/var/mnt/fast/shared-games/` and the Ally at `/home/bazzite/shared-games/`, the exe paths differ, the appids differ, and artwork downloaded on one machine doesn't match what the other machine looks for.
+
+The fix: key the artwork cache by game slug (a stable string I control), not by appid. Store it in `_artwork/<slug>/` inside the Syncthing folder. When `setup-steam.sh` runs on any device, it:
+
+1. Checks if artwork exists in the local cache for this slug
+2. If not, downloads from SteamGridDB (requires API key)
+3. Copies from the slug-keyed cache to Steam's `grid/` directory using the local appid
+
+Syncthing propagates the `_artwork/` directory. Second device runs setup, finds artwork already cached, copies it without hitting the API. One download serves the whole fleet forever.
+
+## sync-peers.sh
+
+`sync-peers.sh` runs the setup locally first, then SSHes to each fleet peer and runs it there too. It detects the current hostname to skip itself:
+
+```bash
+for peer in desktop ally; do
+  [ "$peer" = "$(hostname -s)" ] && continue
+  ssh "$peer" "STEAMGRIDDB_API_KEY=$STEAMGRIDDB_API_KEY shared-games/_setup/setup-steam.sh"
+done
+```
+
+One command from either machine provisions the whole fleet. The API key is forwarded over SSH when present; peers without a key still get artwork from the Syncthing cache.
+
+## Bidirectional by default
+
+`sync-peers.sh` is designed to run from either device — not just the desktop. If the Ally adds a new game, it can run provisioning and the desktop gets the shortcut on the next sync. The script doesn't assume a master/replica relationship.
+
+## Scripts on GitHub
+
+`_setup/` is a git repo tracking `superterran/shared-games-setup`. Syncthing propagates the scripts to all devices; git tracks their history. No separate sync mechanism needed — the scripts live in the thing they manage.
+
+## Current state
+
+Desktop and Ally: five games fully configured with Steam shortcuts and artwork. `mario64` is present in the folder structure but the binary needs to be built from source — the script skips it gracefully when no binary is found. SNES ROM hacks need EmuDeck per-device, not automated.

--- a/content/posts/2026-05-24-openclaw-multi-agent-coordination.md
+++ b/content/posts/2026-05-24-openclaw-multi-agent-coordination.md
@@ -1,0 +1,60 @@
+---
+title: "coordinating multiple slack bots in shared channels"
+date: 2026-05-24
+draft: false
+categories: ["homelab"]
+tags: ["openclaw", "slack", "multi-agent", "bots", "coordination"]
+summary: "Two AI agents writing duplicate artifacts in the same Slack channel. Prompt-level 'stay in your lane' doesn't work — it can't win a race. Structural fixes do."
+---
+
+OpenClaw runs multiple AI agents across a few Slack workspaces. Some channels have more than one agent with write access. The problem that emerged: in high-activity threads, two agents would respond to the same message in parallel and produce conflicting or duplicate artifacts — both writing the same document update, both posting the same answer. Prompt coordination ("don't respond if the other agent already has") is too slow. It can't win a race between two parallel agent turns.
+
+The structural fixes that work:
+
+## requireMention gate
+
+Per-channel `requireMention: true` makes an agent fire in that channel only when directly `@`-mentioned. In any shared channel, designate one agent as the operational primary (responds freely) and make the other a consultant (responds only when tagged). A primary that never tags the consultant = no interference.
+
+This is the core fix. Everything else is layered on top of it.
+
+## Orchestrator / consultant pattern
+
+The primary is also the orchestrator. When the consultant is needed, the primary decides when to tag them and with what specific ask. Single-head decision — no race condition because only the primary can initiate the consultant.
+
+What makes this work in practice: the primary reads the thread first, determines what's needed, then either handles it or tags the consultant with a specific question. "What's your take on X?" not just a bare ping. The consultant does their job and exits.
+
+## `slack_read_thread` as the mandatory first tool call
+
+In any shared-bot channel, session memory is unreliable as a source of truth — each agent's session is isolated and doesn't include other agents' recent messages. The live thread is the only source of truth. Making `slack_read_thread` the mandatory first tool call before any action ensures the agent is working from current state, not a stale cached view.
+
+Without this: an agent wakes up in a thread, misses what the other agent just did, and posts a duplicate.
+
+## `[state]` pins
+
+After any canonical state change (new artifact, owner change, action closed), post one line in thread:
+
+```
+[state] <summary>. Owner: <who>. Open: <what>.
+```
+
+Most recent wins. This is cheap — one line of text — and visible to both humans and agents on thread read. When an agent wakes up in an existing thread and reads back, the most recent `[state]` line gives it an anchor. No need to parse the whole thread's history to figure out where things stand.
+
+## Cron session-key vs. isolated sessions
+
+Some agents do work via scheduled cron tasks that touch active threads. The wrong pattern: `--session isolated`. An isolated cron task's work doesn't appear in the agent's thread session memory. The agent subsequently re-enters the thread with no memory of what the cron task just did.
+
+The right pattern: `--session-key agent:<name>:channel:<id>:thread:<ts>`. Session-keyed cron tasks join the same session as the thread, so their work is visible in subsequent turns.
+
+---
+
+## The OpenClaw upgrade (2026.5.7 → 2026.5.19)
+
+Ran the queued upgrade in the same session. One thing worth noting: the TrueNAS catalog moves past staged versions quickly. The runbook said target version `1.0.32` (2026.5.18); by the time the upgrade ran, the catalog only offered `1.0.33` (2026.5.19). The delta was small — a stable rollup plus one point release. Confirm the available version via `midclt call app.upgrade_summary <app>` immediately before running, not by trusting a hardcoded version in a runbook written a week earlier.
+
+Post-upgrade all Slack sockets reconnected cleanly. The upgrade included a restart-drain fix that had been causing cron jobs to get interrupted by gateway restarts — confirmed by checking cron job error counts, which showed two consecutive failures on the dreaming pipeline. Manually triggered the failed job, confirmed it ran successfully, error count reset.
+
+## Per-agent flutter tuning
+
+When an agent in a Slack channel is "thinking," a typing indicator shows. With multiple agents in a channel, you want this to mean something — flutter only when there's actual content incoming, not on every wakeup.
+
+In 2026.5.19, per-agent `typingMode` isn't configurable directly. The workable configuration: `reasoningDefault: "stream"` and `thinkingDefault: "medium"` per-agent, with `typingMode: "thinking"` in the global defaults. This makes the flutter appear while reasoning is streaming and stay quiet otherwise. Hot-reloads without a gateway restart.


### PR DESCRIPTION
Last four from the session backlog (#27, #28, #34, #49). Shared games arc in three posts (initial setup, ROG Ally provisioning, fleet rewrite). Final post covers the structural fixes for multi-agent Slack coordination + OpenClaw upgrade. All content-only, no redaction needed.