### PR TITLE
add 6 redacted session posts (Mar–May 2026)

### DIFF
--- a/content/posts/2026-03-14-vault-backup-watcher.md
+++ b/content/posts/2026-03-14-vault-backup-watcher.md
@@ -1,0 +1,50 @@
+---
+title: "real-time obsidian vault backup with inotifywait and git"
+date: 2026-03-14
+draft: false
+categories: ["homelab"]
+tags: ["obsidian", "systemd", "git", "inotifywait", "backup", "bazzite"]
+summary: "A polling git backup every hour is fine until you need the last 59 minutes. inotifywait watches for file events and pushes within 30 seconds of any change."
+---
+
+A timer-based vault backup running every hour leaves up to 59 minutes of work unprotected. The better approach: watch for file events and push when something actually changes.
+
+## inotifywait as the backbone
+
+`inotifywait` from the `inotify-tools` package watches a directory for events — creates, modifies, moves. The backup script runs in a loop: wait for an event, debounce briefly, run `git add -A && git commit && git push`. Latency between a vault change and a backup commit is typically under 30 seconds.
+
+```bash
+inotifywait -r -m -e create -e modify -e moved_to --format '%w%f' "$VAULT_DIR" | while read file; do
+  # debounce
+  sleep 5
+  # drain remaining events
+  while read -t 1 file; do :; done
+  # commit and push
+  git -C "$VAULT_DIR" add -A
+  git -C "$VAULT_DIR" commit -m "auto-backup $(date -u +%Y-%m-%dT%H:%M:%SZ)" --allow-empty-message
+  git -C "$VAULT_DIR" push
+done
+```
+
+The debounce matters: Obsidian writes multiple small changes during a save. Without it, you'd get a push for each file in a bulk operation. The `read -t 1` drain loop after the sleep catches any events that queued up during the debounce window.
+
+## systemd unit: paths with spaces
+
+The vault is at `~/Documents/Cloud Vault/` — spaces in the path. systemd `ExecStart` and `EnvironmentFile` handle spaces poorly. Two options:
+
+1. Quote with `\x20` escaping in the unit file
+2. Create a symlink from a no-space path (`~/Context`) to the vault directory, and use the symlink in the unit file
+
+Option 2 is more readable. The symlink survives Obsidian Sync, stays portable across machines.
+
+## HTTPS over SSH for the git remote
+
+The vault repo uses HTTPS with `credential.helper=store` rather than SSH. The reason: SSH key auth requires `IdentityAgent` configuration (`%d/.1password/agent.sock` for 1Password SSH), and getting that right inside a non-interactive systemd service is more work than HTTPS + a stored credential. For a personal vault repo, stored HTTPS credentials are acceptable.
+
+One thing: `gh`'s OAuth token doesn't have the `workflow` scope by default. If the vault has `.github/workflows/` files, pushing via the stored gh credential will fail. Use a PAT with `workflow` scope, or avoid pushing workflow files from the watcher.
+
+## The old approach
+
+The previous setup was a systemd timer firing every hour running a similar git push. Replacing the timer with an always-on watcher service means: no polling interval to tune, no "did the change land before or after the last run" ambiguity, no accumulated work lost when the timer fires just after a session ends.
+
+The watcher script lives in the vault itself (`.scripts/watch-and-push.sh`), so it's backed up alongside the content it protects.

--- a/content/posts/2026-03-15-playwright-cloudflare-tunnel-devcontainer.md
+++ b/content/posts/2026-03-15-playwright-cloudflare-tunnel-devcontainer.md
@@ -1,0 +1,44 @@
+---
+title: "e2e testing a local devcontainer through a cloudflare quick tunnel"
+date: 2026-03-15
+draft: false
+categories: ["homelab"]
+tags: ["playwright", "cloudflare", "devcontainer", "testing", "bazzite"]
+summary: "Quick tunnels let Playwright MCP reach a local devcontainer from outside the network. Two gotchas: env.php system config silently overrides database config, and AJAX checkout steps need an explicit wait."
+---
+
+Playwright MCP can drive a browser against any URL — including a local devcontainer exposed through a Cloudflare quick tunnel. This avoids the complexity of running Playwright inside the container itself and lets the test session live in Claude's context window rather than buried in a test runner's output.
+
+## Quick tunnels for devcontainer access
+
+`cloudflared tunnel --url http://localhost:8443` gives a public HTTPS URL that forwards to the local devcontainer. The URL is temporary and changes on each run, but for an interactive test session it's fine — you update the application's base URL setting and run your tests.
+
+Quick tunnels last longer than you'd expect. In practice: 12+ hours without expiring. For a long test session or overnight work, they hold.
+
+## env.php overrides database config
+
+This one is easy to miss. In Magento-family apps (and probably others that layer config the same way), there's a hierarchy:
+
+1. `env.php` system config (highest priority)
+2. `core_config_data` database table
+3. Default values
+
+If `env.php` has `system/default/web/unsecure/base_url` set, running `config:set web/unsecure/base_url https://new-tunnel.trycloudflare.com` appears to succeed — it writes to the database — but has no effect because `env.php` wins at runtime.
+
+The symptom: you update the URL and the app keeps serving the old hostname. The fix is to update `env.php` directly, not the database config.
+
+## Checkout AJAX timing
+
+During checkout, address field changes trigger AJAX recalculations — shipping rates, totals, payment options. The shipping rate radio buttons become temporarily disabled during these recalculations. If Playwright clicks a radio button that's mid-recalculation, the click either fails or lands on a stale element.
+
+Fix: after filling address fields, wait for the recalculation to complete before selecting a shipping method. `waitForSelector('.shipping-method:not([disabled])')` or a network idle wait both work.
+
+## Payment methods aren't on by default
+
+In a fresh dev environment, no payment methods may be configured. The checkout review step shows the payment section but with nothing to select. Enable a simple method via config before testing the full flow — Check/Money Order or Cash on Delivery are both good choices for local test environments since they have no external dependencies.
+
+## Screenshots at every step
+
+The agent can't see the browser. Screenshots are its only view into what's actually happening. Taking a screenshot after each significant action (navigate, form fill, click, page transition) means you can audit what happened after the fact and catch visual regressions that would be invisible in a text-only view.
+
+Playwright MCP with `--save-trace` records a full session trace viewable at `trace.playwright.dev` — useful for post-session debugging without having to replay the test.

--- a/content/posts/2026-04-05-fastmcp-wellbeing-server.md
+++ b/content/posts/2026-04-05-fastmcp-wellbeing-server.md
@@ -1,0 +1,54 @@
+---
+title: "building a personal tracking mcp server with fastmcp"
+date: 2026-04-05
+draft: false
+categories: ["homelab"]
+tags: ["mcp", "fastmcp", "python", "systemd", "sqlite", "health-tracking"]
+summary: "FastMCP makes it straightforward to build a personal data MCP server. Key patterns: separate bridge vs. server, SQLite-backed markdown snapshots, and the systemd EnvironmentFile export gotcha."
+---
+
+FastMCP (Python) handles the MCP server layer cleanly — you write annotated functions, decorate them with `@mcp.tool()`, and the framework handles JSON-RPC, schema generation, and transport. This is the pattern for a personal tracking server: SQLite for storage, a background resource for ambient context, and a separate HTTP bridge for external data ingestion.
+
+## Separate bridge vs. MCP server
+
+Two services, not one:
+
+- The **MCP server** is spawn-on-demand. Claude or another client launches it, uses it, exits. That's fine for queries and updates initiated by the user.
+- The **HTTP bridge** needs to be always-on. If it's waiting to receive data from an external source (an iOS app, a webhook, an API push), it can't be spawn-on-demand — the data arrives when it arrives, not when a client session is open.
+
+The bridge receives incoming data and writes to the shared SQLite database. The MCP server reads from the same database. Clean separation: no shared process, no resource contention, independent restart behavior.
+
+## The MCP resource for ambient context
+
+FastMCP supports `@mcp.resource()` — a URI-addressable resource that gets included in the conversation context automatically when configured, without requiring an explicit tool call. This is useful for a daily snapshot: the current state of whatever you're tracking gets pulled into context at the start of every session.
+
+The resource builds a readable text summary from the database state — today's entries, running totals, recent trends. Text, not JSON — because it's going into a language model's context and should be readable prose.
+
+## SQLite as the storage layer
+
+One database file, standard CRUD. All the entries are insert-only (log entries, not updates), so there's no concurrency issue between the bridge and the server even when they're both running. The bridge writes; the server reads. No locking needed.
+
+## FastMCP's `run_http_async` for remote access
+
+For HTTP/SSE transport (remote Claude instances, Open WebUI), FastMCP 3.2 uses `run_http_async()` with `transport='streamable-http'`. The API changed between major versions — the older `run()` with a transport kwarg doesn't work in 3.x. Worth checking the FastMCP changelog if you're upgrading from an earlier version.
+
+## systemd EnvironmentFile: no `export`
+
+systemd's `EnvironmentFile` directive parses `KEY=value` format. Shell convention is `export KEY=value` — the `export` keyword is not parsed and ends up treated as part of the key name. The result is that the environment variable is never set, with no error message.
+
+```ini
+# works
+EnvironmentFile=/path/to/.env
+
+# .env contents (correct)
+MY_API_KEY=abc123
+
+# .env contents (wrong — export keyword silently breaks it)
+export MY_API_KEY=abc123
+```
+
+If you have a `~/.env` that you source interactively (where `export` is valid syntax), it won't work as an `EnvironmentFile` without modification. Keep separate files for interactive use and systemd, or use the `key=value` format everywhere.
+
+## FastMCP callable-factory pattern
+
+When FastMCP tools need access to a shared resource (like a database connection or a config object), the callable-factory pattern works cleanly: a factory function creates a callable with the shared state closed over it, and that callable is passed to `mcp.add_tool()`. This sidesteps the need for global state while keeping each tool function testable in isolation. The pattern was stabilized in FastMCP 3.x after some API churn in earlier versions — if you see decorator-based tools not binding correctly, checking whether you're closing over a connection or passing it explicitly is a good first debug step.

--- a/content/posts/2026-04-11-local-voice-ai-stack.md
+++ b/content/posts/2026-04-11-local-voice-ai-stack.md
@@ -1,0 +1,40 @@
+---
+title: "building a local voice ai stack with open webui, kokoro, and speaches"
+date: 2026-04-11
+draft: false
+categories: ["homelab"]
+tags: ["ollama", "open-webui", "kokoro", "speaches", "cloudflare", "bazzite", "voice-ai"]
+summary: "Open WebUI for the interface, Kokoro for TTS, Speaches (faster-whisper) for STT, Ollama for the model. One VRAM constraint, one auth pattern, one Cloudflare gotcha."
+---
+
+The local voice AI stack on bazzite-desktop: Open WebUI as the interface, Kokoro for text-to-speech, Speaches (faster-whisper) for speech-to-text, all backed by a locally-running large model via Ollama. Exposed publicly through the existing Cloudflare Tunnel with two different auth patterns for the web UI vs. API endpoints.
+
+## VRAM budget forces Kokoro onto CPU
+
+The machine is running a large model in Ollama that holds most of the GPU's VRAM. Kokoro's GPU image needs several gigabytes that aren't available while Ollama is running.
+
+The good news: Kokoro TTS is a small model (82M parameters). It runs fine on CPU — slower than GPU, but the latency for speech synthesis is acceptable for conversational use. The CPU variant of the Kokoro Docker image solves the contention without requiring any scheduling coordination.
+
+Speaches (faster-whisper STT) gets GPU access since its VRAM footprint is lighter. The `medium` whisper model fits in the remaining headroom.
+
+## Two auth patterns: web UIs vs. API endpoints
+
+Web UIs (Open WebUI itself) go through Cloudflare Access with email OTP. The result: visiting the URL prompts for a one-time code sent to the authorized email. No credentials embedded anywhere, no password database to maintain.
+
+API endpoints — specifically the Ollama API, which external clients like iOS apps and scripts need to hit programmatically — can't do OTP flows. Those go through Caddy as a bearer token proxy: Caddy sits in front of Ollama, validates an `Authorization: Bearer ...` header, and proxies to the local Ollama socket. The public tunnel routes API traffic through Caddy.
+
+## Remotely-managed tunnel configuration
+
+This was the unexpected part. The Cloudflare Tunnel is "remotely managed" — ingress rules are stored in Cloudflare's API, not in a local `config.yml`. Editing the local config file does nothing; the remote config is what actually controls routing.
+
+Adding new subdomains requires an API call to update the remote ingress config. Worth checking whether your tunnel is `local` or `cloudflare`-managed before spending time editing a file that isn't being read.
+
+## The catch-all redirect rule
+
+The zone had a dynamic redirect rule catching all traffic to unrecognized `*.superterran.net` subdomains and 301-redirecting to another domain. New subdomains added to the tunnel ingress weren't exempt from this rule — requests to the new hostnames hit the redirect before reaching the tunnel.
+
+Fix: add each new hostname to the catch-all rule's exclusion list before wiring it into the tunnel. The symptom (redirect to unexpected domain instead of the expected service) is confusing if you haven't seen this pattern before.
+
+## Open WebUI audio configuration
+
+Open WebUI's STT and TTS integrations are in Admin → Settings → Audio. The fields expect OpenAI-compatible endpoints — Speaches and Kokoro both implement the OpenAI audio API surface (`/v1/audio/transcriptions`, `/v1/audio/speech`), so they drop in directly. Set the base URLs and the model names, and voice mode works.

--- a/content/posts/2026-05-05-magento-devcontainer-template.md
+++ b/content/posts/2026-05-05-magento-devcontainer-template.md
@@ -1,0 +1,55 @@
+---
+title: "publishing a devcontainer template to ghcr with oci distribution"
+date: 2026-05-05
+draft: false
+categories: ["homelab"]
+tags: ["devcontainers", "docker", "ghcr", "oci", "github-actions", "mkcert"]
+summary: "Option D architecture for devcontainer templates: working repos publish directly to a shared GHCR namespace. Three gotchas: cross-repo package ownership, Docker Compose variable syntax conflict, and a broken devcontainers-cli feature."
+---
+
+The devcontainers spec supports publishing templates and features to any OCI registry. The publish toolchain is `devcontainer templates publish` — but getting it wired up involves a few non-obvious decisions about registry layout and build tooling.
+
+## Option D: working repos publish to a shared namespace
+
+There are a few viable architectures for hosting devcontainer templates. The one that worked here:
+
+- A shared GHCR namespace (`ghcr.io/<username>/devcontainer-templates`) holds all published template OCI artifacts
+- Each project repo contains its own template source under `.devcontainer/`
+- A GitHub Actions workflow in each project repo runs `devcontainer templates publish` on push, targeting the shared namespace
+
+This keeps template source co-located with the project that uses it, while making the published artifact discoverable from a single namespace. No separate "templates monorepo" required.
+
+## GHCR cross-repo package ownership
+
+Publishing to `ghcr.io/<username>/devcontainer-templates` from a repo other than `<username>/devcontainer-templates` requires an explicit package ownership grant. GHCR ties package write access to repository identity by default — a workflow in `my-project` cannot write to the `devcontainer-templates` package without being listed as an authorized repository.
+
+This grant lives in the GHCR UI under the package settings, not in GitHub Actions or repository settings. The workflow token needs `packages: write` permission and the source repo needs to be added to the package's linked repositories list. Without the UI grant, the push fails with a 403 even if the token has the right scopes.
+
+## Docker Compose variable syntax conflict
+
+The devcontainers `devcontainer.json` template spec uses `${templateOption:optionName}` syntax for template variables. Docker Compose uses `${VARIABLE_NAME}` syntax for environment variable substitution. When a `devcontainer.json` references Docker Compose files and also contains `${templateOption:...}` tokens, the Compose parser intercepts and rejects the template variable syntax before the devcontainer toolchain can process it.
+
+The fix: don't rely on the devcontainer CLI to do template variable substitution at build time when Compose is involved. Instead, a `build.sh` script applies the substitutions manually (simple `sed` replacements) on the template source before passing it to `devcontainer templates publish`. The published artifact contains the already-substituted values. This means one published variant per option combination rather than a single parameterized artifact, but for a small option matrix that's fine.
+
+## Broken devcontainers-cli feature
+
+The `devcontainers-extra/features/devcontainers-cli:1` feature installs the `@devcontainers/cli` npm package inside the container. At time of writing, the feature script references the `lts` npm dist-tag, which doesn't exist for this package — `lts` is a Node.js concept, not an npm package dist-tag. The install fails with a 404.
+
+Fix: install `@devcontainers/cli` directly via a `postCreateCommand` or a custom feature, skipping the broken community feature entirely. `npm install -g @devcontainers/cli@latest` works fine.
+
+## Multi-arch mkcert
+
+mkcert is distributed as pre-built binaries. The install script needs to detect the architecture and pull the correct binary. The standard pattern:
+
+```bash
+ARCH=$(uname -m)
+case $ARCH in
+  x86_64)  MKCERT_ARCH="amd64" ;;
+  aarch64) MKCERT_ARCH="arm64" ;;
+  *)       echo "unsupported arch: $ARCH"; exit 1 ;;
+esac
+curl -Lo /usr/local/bin/mkcert \
+  "https://github.com/FiloSottile/mkcert/releases/latest/download/mkcert-v$(...)_linux-${MKCERT_ARCH}"
+```
+
+Skipping the arch detection works fine until someone builds on an Apple Silicon machine or a Graviton runner. Worth doing upfront.

--- a/content/posts/2026-05-17-openclaw-subscription-bridge.md
+++ b/content/posts/2026-05-17-openclaw-subscription-bridge.md
@@ -1,0 +1,46 @@
+---
+title: "wiring openclaw to claude cli with subscription billing"
+date: 2026-05-17
+draft: false
+categories: ["homelab"]
+tags: ["openclaw", "claude", "mcp", "docker", "billing", "litellm"]
+summary: "OpenClaw's native anthropic plugin bills against a metered pool; the claude-cli provider uses your Claude subscription instead. Three non-obvious pieces: an API key stripping wrapper, a silent per-agent model constraint, and an insecure WebSocket flag for same-host Docker networking."
+---
+
+OpenClaw supports two ways to connect to Claude: the native `anthropic` plugin (direct API) and the `claude-cli` provider (shells out to the `claude` binary). The billing difference matters: the `anthropic` plugin bills against a metered API usage pool; `claude-cli` uses the Claude subscription on the account the binary is logged in to. For a homelab running continuous agent sessions, the subscription path is substantially cheaper.
+
+## The ANTHROPIC_API_KEY stripping wrapper
+
+OpenClaw injects `ANTHROPIC_API_KEY` into the environment for its native plugin. The `claude` CLI binary sees this environment variable and treats it as a literal API key — which it isn't; it's an OAuth token in OpenClaw's format. The CLI rejects it and authentication fails.
+
+Fix: a wrapper script at `/home/node/bin/claude` that unsets `ANTHROPIC_API_KEY` before exec-ing the real binary:
+
+```bash
+#!/bin/bash
+unset ANTHROPIC_API_KEY
+exec /usr/local/bin/claude-real "$@"
+```
+
+With the wrapper in `PATH` before the real binary, OpenClaw's `claude-cli` provider calls the wrapper, which clears the injected key, and the binary authenticates normally via its stored credential.
+
+## Per-agent models.json is a silent constraint
+
+OpenClaw allows per-agent model configuration via a `models.json` file. If `claude-cli` isn't listed as an available provider in that file, OpenClaw falls back silently to whatever provider is listed — it doesn't error, it just picks the next option. If the fallback is an unconstrained LiteLLM-routed model, requests that should be going to Claude end up elsewhere without any log warning.
+
+The symptom: responses that seem weirdly inconsistent with Claude's behavior. Check `models.json` for the agent and confirm `claude-cli` is explicitly listed before assuming the billing or auth setup is broken.
+
+## openclaw-mcp SSE bridge
+
+The `openclaw-mcp` bridge exposes OpenClaw's internal channels API as MCP tools, accessible over HTTP/SSE. This lets Claude sessions (or other MCP clients) read and write to OpenClaw channels without going through the Slack surface. Useful for agent-to-agent coordination that doesn't need to be visible in Slack.
+
+Configuration is minimal — point the MCP client at the bridge endpoint and provide a bearer token. The bridge itself runs as a Docker container alongside the OpenClaw gateway.
+
+## alpine/openclaw is Debian
+
+The `alpine/openclaw` Docker image name is misleading. Despite the namespace, the image runs Debian bookworm, not Alpine Linux. This matters when you're installing packages or debugging the container — `apk` doesn't exist, `apt` does. The namespace reflects the publishing org, not the base OS.
+
+## OPENCLAW_ALLOW_INSECURE_PRIVATE_WS
+
+When the `openclaw-mcp` bridge runs in a Docker container on the same host as the OpenClaw gateway, it connects to the gateway over a Docker network interface. Docker bridge networks use RFC 1918 addresses, but they're not loopback — the gateway's TLS configuration may reject non-loopback WebSocket connections by default.
+
+Setting `OPENCLAW_ALLOW_INSECURE_PRIVATE_WS=1` in the bridge container's environment allows the WebSocket connection to proceed over the Docker network without TLS. Only appropriate for same-host Docker deployments where the traffic never leaves the machine.


### PR DESCRIPTION
## Posts

- 2026-03-14 vault backup watcher (inotifywait+git, systemd path-with-spaces)
- 2026-03-15 playwright through cloudflare quick tunnel (env.php override, checkout AJAX timing)
- 2026-04-05 fastmcp wellbeing server (bridge vs server, SQLite, callable-factory)
- 2026-04-11 local voice AI stack (Kokoro CPU, Caddy bearer auth, remotely-managed tunnel)
- 2026-05-05 devcontainer template OCI publish (Option D arch, GHCR cross-repo ownership, Compose syntax conflict)
- 2026-05-17 openclaw billing bridge (claude-cli vs anthropic plugin, API key stripping wrapper, per-agent models.json)

All BA/household context stripped per opsec rules.