### PR TITLE
the billing backoff was set to 24h

### DIFF
--- a/content/posts/2026-06-14-billing-backoff.md
+++ b/content/posts/2026-06-14-billing-backoff.md
@@ -1,0 +1,18 @@
+---
+title: "the billing backoff was set to 24h"
+date: 2026-06-14
+draft: false
+categories: ["ai"]
+tags: ["openclaw", "configuration", "agents", "gotcha"]
+summary: "The default billingBackoffHours value means one brief Claude quota hit locks out all agents until the next day."
+---
+
+One of the bots went quiet. Then two. Then I realized they'd all gone dark around the same time.
+
+The root cause was `auth.cooldowns.billingBackoffHours: 24` — the default. When Claude's subscription quota gets hit (even briefly, even late in the day), OpenClaw backs off from that auth provider for 24 hours. There's no automatic retry, no grace period. If all agents share the same fallback chain and none have a working provider left, they don't respond. They don't error. They just stop.
+
+Changed it to 1. A brief cap hit now means a one-hour cooldown, not a lost day.
+
+The fix I added alongside: an all-Claude fallback chain (sonnet → sonnet → opus) without any auto-fallback to a metered provider. Codex had been quietly entering the chain when Claude was capped — not as a deliberate backup, just next in the list. I hadn't noticed because the output looked the same. Switched to Claude providers only, shorter backoff, and a watchdog cron that alerts on sustained failures.
+
+I don't know what the right value for `billingBackoffHours` is in general. One hour might be too short if you're against a hard cap and retrying just racks up failed turns. But 24 is definitely not right for a personal assistant stack where you're not watching the logs.


### PR DESCRIPTION
Source: [2026-06-13-openclaw-robustness-iac](vault://Context/sessions/2026-06-13-openclaw-robustness-iac)

Post-worthy because: discovered that `auth.cooldowns.billingBackoffHours: 24` (the default) was silently locking out all OpenClaw agents for a full day whenever Claude's subscription quota was briefly hit. The fix (change to 1) is one line but took a full robustness investigation to surface. Classic "gotcha that took 30 minutes is a better post than the 2-hour architecture overview."

**Guardrail self-check:**
- Hard-banned topics avoided? YES
- All proper nouns are public tools/products? YES
- Title passes voice ban list? YES (lowercase fragment, no alliteration, no "How I", no listicle opener)
- Under 1000 words? YES (~230 words)
- Ends without CTA or wrap-up? YES
- Content from confidential channels? NO
- OpSec (no internal IPs/ports, no auth gaps, no IaC internals)? YES