### PR TITLE
gh release create still needs git

### DIFF
--- a/content/posts/2026-06-26-gh-release-create-needs-checkout.md
+++ b/content/posts/2026-06-26-gh-release-create-needs-checkout.md
@@ -1,0 +1,16 @@
+---
+title: "gh release create still needs git"
+date: 2026-06-26
+draft: false
+categories: ["tools"]
+tags: ["github", "github-actions", "gh-cli", "gotcha"]
+summary: "Setting GH_REPO in a GitHub Actions job isn't enough for gh release create — it still shells out to git internally, so you get 'fatal: not a git repository' without a checkout step."
+---
+
+Running `gh release create` in a GitHub Actions job with no checkout step. Set `GH_REPO=org/repo` — which is the documented way to point `gh` at a target repo from outside one. Job still died: `fatal: not a git repository`.
+
+The assumption was that `GH_REPO` would make `gh` fully repo-aware. It does for most things. `gh release create` is different: it shells out to `git` internally at some point, and `git` wants an actual directory with a `.git/` folder, not an env var.
+
+Fix: `actions/checkout@v4` at the top of the job, before the release step. Doesn't need a deep clone — `fetch-depth: 1` is fine. Just needs the directory context so `git` doesn't bail.
+
+The error message is a dead end. "Not a git repository" points at your checkout setup, not at `GH_REPO`.


### PR DESCRIPTION
From the 2026-06-25 waccamaw/members-service sweep: `gh release create` kept dying with `fatal: not a git repository` even after setting `GH_REPO=org/repo`. Root cause: `gh` shells out to `git` internally, which needs an actual checkout directory, not just an env var. Fix was adding `actions/checkout@v4` at the top of the job.

**Guardrail self-check:**
- Avoids all hard-banned topics? YES
- Proper nouns: only GitHub Actions / gh CLI / actions/checkout (all widely-known tools) — YES
- Title passes voice ban? YES (no alliteration, no "How I", no listicle)
- Under 1000 words? YES (~155 words)
- No CTA or wrap-up paragraph? YES
- No confidential channel content? YES