### PR TITLE
wayback toolbar files loaded as scripts

### DIFF
--- a/content/posts/2026-06-27-wayback-toolbar-as-script.md
+++ b/content/posts/2026-06-27-wayback-toolbar-as-script.md
@@ -1,0 +1,24 @@
+---
+title: "wayback toolbar files loaded as scripts"
+date: 2026-06-27
+draft: false
+categories: ["homelab"]
+tags: ["wayback", "museum", "javascript", "gotcha", "playwright"]
+summary: "Archiving old site snapshots from Wayback? The .js files it saved might be HTML toolbar pages — browsers throw 'Unexpected token <' and the error points at nothing useful."
+---
+
+Running a Playwright QA pass over the museum archive. Loaded a 2008-era snapshot page. Five JS exceptions in the console, all the same shape:
+
+```
+Uncaught SyntaxError: Unexpected token '<'
+```
+
+All from `superterran-2008/assets/*.js`.
+
+First assumption: bad JS from 2008. The reality: those aren't JS files. When Wayback Machine crawled the original site, some referenced scripts were already dead. Wayback saved those failed fetches as HTML — the Wayback toolbar wrapper page — with the original `.js` filename intact. So the assets directory has files with `.js` extensions that contain HTML.
+
+A browser loading them as `<script src>` gets HTML, hits the `<` in `<!DOCTYPE`, and throws. The error points at the filename. It doesn't say "this file contains HTML." So first instinct is to read the script logic — there is no script logic to read.
+
+Fix was deleting the stub files. The scripts they referenced were already dead at crawl time; removing them cleared all five exceptions.
+
+Same thing can happen with `.css` and image files. Wayback saves the toolbar HTML whatever the original extension was. If a crawled resource was a 404 at crawl time, the saved asset is an HTML page wearing the wrong filename.


### PR DESCRIPTION
Source: vault session `Context/sessions/2026-06-21-museum-quality-pass.md`

Post-worthy because: classic "wrong-error-message" gotcha — `Unexpected token '<'` sounds like bad JS logic, but the file is HTML (a Wayback toolbar wrapper saved with a `.js` extension). Zero search results explain it clearly.

## Guardrail self-check

- **Hard-banned topics avoided?** YES — no work names, no household/partner/family, no confidential channels, no wellbeing data, no BA work, no secrets or internal IPs.
- **Proper nouns OK?** YES — only `Wayback Machine` (widely-known tool) and the site's own public hostname context. No client or coworker names.
- **Title passes voice ban list?** YES — lowercase/fragmentary, no "How I", no alliteration, no listicle opener.
- **Under 1000 words?** YES — ~200 words.
- **No CTA or wrap-up paragraph?** YES — ends on the observation.
- **No confidential-channel content?** YES — the museum archive is a public site; QA work on it is fair game.