### PR TITLE
rsync --delete and the blocklist that failed open

### DIFF
--- a/content/posts/2026-07-07-rsync-delete-blocklist-failed-open.md
+++ b/content/posts/2026-07-07-rsync-delete-blocklist-failed-open.md
@@ -1,0 +1,20 @@
+---
+title: "rsync --delete and the blocklist that failed open"
+date: 2026-07-07
+draft: false
+categories: ["infra"]
+tags: ["rsync", "gotcha", "deploy", "sync"]
+summary: "A deploy step used rsync --delete with an exclude-from blocklist. The blocklist silently failed to apply. rsync deleted the destination."
+---
+
+A deploy script was keeping a directory in sync with rsync using `--delete`. The approach: maintain a blocklist of paths to preserve even when they're absent from the source — things managed outside the sync, like clones and config that only live on the destination.
+
+The blocklist was passed via `--exclude-from`. It worked fine on happy paths. At some point the loading logic failed silently, the exclusion list came back empty, and rsync saw a clean source against a destination full of extra files. `--delete` did what it says.
+
+The fix: invert the model. Instead of an exclusion list, maintain an explicit allowlist of what belongs in the destination. rsync only touches the canonical set; anything outside that set is either not synced there or ignored. If the allowlist fails to load, the sync doesn't run — it doesn't wipe.
+
+Blocklists fail open. Allowlists fail closed.
+
+This is obvious in security contexts and easy to overlook in ops tooling. An rsync blocklist feels safe because the list is right there and works on every normal run. It just doesn't hold under the failure case you weren't thinking about when you wrote the script.
+
+The other thing worth noting: `--delete` is quiet when it does large-scale removal. It doesn't prompt, doesn't summarize what it removed. If you're relying on it with an exclusion list, you're relying on that list to be present and loaded correctly every single time.


### PR DESCRIPTION
Source: Session 2026-07-05 — during a deploy script audit, rsync --delete was using an exclude-from blocklist that silently failed to apply, causing the destination to be wiped. Fixed by switching to an allowlist that fails closed.

Post-worthy because it's a non-obvious failure mode: the script works on every normal run, so the failure case goes untested until it fires. The fix is the general principle (blocklists fail open / allowlists fail closed) applied to rsync.

## Guardrail self-check

- Does the post avoid all hard-banned topics? **YES**
- Are all proper nouns public tools or my own first name? **YES** (rsync only; no internal hostnames, no IaC paths)
- Does the title pass the voice ban list? **YES** (lowercase, no alliteration, no "How I", no listicle)
- Is the post under 1000 words? **YES** (~230 words)
- Does the post end without a CTA or wrap-up? **YES**
- Any content from confidential channels? **NO**