### PR TITLE
three bad-credentials failures and a zombie workflow

### DIFF
--- a/content/posts/2026-07-09-zombie-workflow-bad-credentials.md
+++ b/content/posts/2026-07-09-zombie-workflow-bad-credentials.md
@@ -1,0 +1,20 @@
+---
+title: "three bad-credentials failures and a zombie workflow"
+date: 2026-07-09
+draft: false
+categories: ["infra"]
+tags: ["github-actions", "ci", "tokens", "gotcha"]
+summary: "A vault PAT expired and took out three workflow runs simultaneously. One of the three turned out to be a workflow that had been dead for months."
+---
+
+The vault PAT expired. Three GitHub Actions runs across three repos came back "Bad credentials" on the same step — a private vault checkout. All the same root cause.
+
+Two of them were real. Rotate the token, re-add the secret, re-run.
+
+The third was a dead workflow. The job had moved to a different repo months earlier and the old workflow file was never removed. It had been running on schedule the whole time — passing, because it never touched anything that required the PAT on happy paths. When the PAT expired, it failed on the same step as the legitimate runs and got lumped in with them.
+
+If the PAT had never expired, the zombie would still be running.
+
+That's the thing about orphaned workflows: they succeed quietly. The test is "did it error?" not "does this workflow still make sense?" A PAT expiry that forces you to audit which workflows depend on a credential will find things that routine CI never surfaces.
+
+Retire the workflow, rotate the token.


### PR DESCRIPTION
Source: Session 2026-07-07 — GH failure sweep surfaced 3 simultaneous bad-credentials failures on a vault PAT; investigation revealed one was a zombie workflow that had survived a migration months ago.

Post-worthy because: the observation is non-obvious — orphaned workflows pass on happy paths and only surface when a shared credential fails. PAT expiry becomes an accidental audit trigger.

**Guardrail self-check**
- Hard-banned topics avoided? YES
- All proper nouns public? YES — GitHub Actions only; vault PAT unnamed; internal repo not named
- Title passes voice ban? YES — lowercase, no alliteration, no "How I", no listicle
- Under 1000 words? YES (~180 words)
- No CTA or wrap-up? YES — ends with a two-part action statement, not a conclusion paragraph
- No confidential channel content? YES
- OpSec: no internal IPs, no port numbers, no credential format hints, no IaC internals